### PR TITLE
Deep code analysis for critical bug identification

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -130,6 +130,17 @@ static void render_rows(void) {
             row_len = (size_t)snprintf(
                 rowbuf, rowbuf_cap, " %*lu ", (int)digits, (unsigned long)lnum
             );
+            /*
+             * snprintf возвращает длину, которую *нужно* было бы записать.
+             * Если буфер оказался короче, реальная строка уже обрезана по
+             * rowbuf_cap – 1 символ. Однако возвращаемое значение остаётся
+             * больше размера буфера. Мы сбрасываем row_len до предельного
+             * значения, чтобы последующие операции (rowbuf[row_len] = '\0',
+             * memcpy/memcmp и т. д.) не выходили за границы памяти.
+             */
+            if (row_len >= rowbuf_cap) {
+                row_len = rowbuf_cap - 1;  /* последний байт — под NUL */
+            }
         }
         if (!line) {
             if (

--- a/src/render.c
+++ b/src/render.c
@@ -130,16 +130,8 @@ static void render_rows(void) {
             row_len = (size_t)snprintf(
                 rowbuf, rowbuf_cap, " %*lu ", (int)digits, (unsigned long)lnum
             );
-            /*
-             * snprintf возвращает длину, которую *нужно* было бы записать.
-             * Если буфер оказался короче, реальная строка уже обрезана по
-             * rowbuf_cap – 1 символ. Однако возвращаемое значение остаётся
-             * больше размера буфера. Мы сбрасываем row_len до предельного
-             * значения, чтобы последующие операции (rowbuf[row_len] = '\0',
-             * memcpy/memcmp и т. д.) не выходили за границы памяти.
-             */
             if (row_len >= rowbuf_cap) {
-                row_len = rowbuf_cap - 1;  /* последний байт — под NUL */
+                row_len = rowbuf_cap - 1;
             }
         }
         if (!line) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix out-of-bounds access in `render_rows` by correctly handling `snprintf` return value to prevent crashes.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `snprintf` function returns the number of characters that *would have been written* if the buffer was large enough, not the number actually written when truncated. If this value (`row_len`) exceeds the buffer capacity (`rowbuf_cap`), subsequent operations like `rowbuf[row_len] = '\0'` or `memcpy` using `row_len` would access memory out of bounds, leading to segmentation faults, especially noticeable in very narrow terminal windows with many lines.
