### PR TITLE
Implement minimalist syntax highlighting for files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ CC ?= gcc
 PLAT := $(if $(filter Windows_NT,$(OS)),win,unix)
 SRC := $(filter-out src/win.c src/unix.c,$(wildcard src/*.c)) \
        src/$(PLAT).c
+SYNTAX_SRC := $(wildcard syntax/*.c)
 OBJ := $(SRC:src/%.c=obj/%.o)
+SYNTAX_OBJ := $(SYNTAX_SRC:syntax/%.c=obj/syntax/%.o)
 OUT := yoc$(if $(filter Windows_NT,$(OS)),.exe,)
 
 CFLAGS += -std=c17 -Iinclude -D_FILE_OFFSET_BITS=64 \
@@ -19,6 +21,7 @@ LDFLAGS += -Wl,--gc-sections -s
 endif
 
 -include $(OBJ:.o=.d)
+-include $(SYNTAX_OBJ:.o=.d)
 
 all: release
 
@@ -32,13 +35,18 @@ debug: build
 
 build: $(OUT)
 
-$(OUT): $(OBJ)
+$(OUT): $(OBJ) $(SYNTAX_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 obj/%.o: src/%.c | obj
 	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 
+obj/syntax/%.o: syntax/%.c | obj/syntax
+	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
+
 obj:
+	mkdir -p $@
+obj/syntax:
 	mkdir -p $@
 
 clean:

--- a/include/syntax.h
+++ b/include/syntax.h
@@ -1,0 +1,41 @@
+#ifndef YOC_SYNTAX_H
+#define YOC_SYNTAX_H
+
+#include "yoc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct SyntaxImpl {
+    const char *name;
+    const char *const *exts;
+    size_t num_exts;
+    void (*write)(const unsigned char *s, size_t len);
+} SyntaxImpl;
+
+// Called on every refresh or when file path potentially changes.
+void syntax_set_file(const char *path);
+
+// Whether highlighting is currently active for the opened file.
+bool_t syntax_enabled(void);
+
+// Write a colored rendering of the given line bytes to the terminal.
+// Does not modify buffers; only emits ANSI sequences via term_write.
+void syntax_write_line(const unsigned char *s, size_t len);
+
+// Generic writers (used by language stubs)
+void syntax_write_clike(const unsigned char *s, size_t len);
+void syntax_write_py(const unsigned char *s, size_t len);
+void syntax_write_sh(const unsigned char *s, size_t len);
+void syntax_write_json(const unsigned char *s, size_t len);
+void syntax_write_html(const unsigned char *s, size_t len);
+void syntax_write_ini(const unsigned char *s, size_t len);
+void syntax_write_sql(const unsigned char *s, size_t len);
+void syntax_write_md(const unsigned char *s, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/render.c
+++ b/src/render.c
@@ -15,6 +15,313 @@ static size_t   lineno_pad             = 0;
 static bool_t   prev_scrollbar_visible = FALSE;
 static uint64_t cached_digest          = 0;
 bool_t          show_line_numbers      = TRUE;
+
+// --- Minimal syntax highlighting (terminal ANSI) ---
+// We keep stored screen buffers plain. We only inject ANSI during writes.
+// This ensures width calculations remain correct.
+
+typedef enum {
+    SYNTAX_NONE = 0,
+    SYNTAX_CLIKE,
+    SYNTAX_PY,
+    SYNTAX_SHELL,
+    SYNTAX_JSON,
+    SYNTAX_HTML,
+    SYNTAX_MD,
+    SYNTAX_INI,
+    SYNTAX_SQL,
+} SyntaxMode;
+
+static SyntaxMode syntax_mode = SYNTAX_NONE;
+
+static int ends_with_ci(const char *s, const char *ext) {
+    size_t ls = strlen(s), le = strlen(ext);
+    if (le > ls) return 0;
+    s += ls - le;
+    for (size_t i = 0; i < le; ++i) {
+        char a = s[i], b = ext[i];
+        if (a >= 'A' && a <= 'Z') a = (char)(a - 'A' + 'a');
+        if (b >= 'A' && b <= 'Z') b = (char)(b - 'A' + 'a');
+        if (a != b) return 0;
+    }
+    return 1;
+}
+
+static int equals_ci(const char *a, const char *b) {
+    size_t la = strlen(a), lb = strlen(b);
+    if (la != lb) return 0;
+    for (size_t i = 0; i < la; ++i) {
+        char ca = a[i], cb = b[i];
+        if (ca >= 'A' && ca <= 'Z') ca = (char)(ca - 'A' + 'a');
+        if (cb >= 'A' && cb <= 'Z') cb = (char)(cb - 'A' + 'a');
+        if (ca != cb) return 0;
+    }
+    return 1;
+}
+
+static void detect_syntax_from_path(void) {
+    const char *path = editor.file.path;
+    const char *name = path && path[0] ? extract_filename(path) : "";
+    syntax_mode = SYNTAX_NONE;
+    if (name[0] == '\0') return;
+    if (equals_ci(name, "makefile")) { syntax_mode = SYNTAX_INI; return; }
+    if (
+        ends_with_ci(name, ".c")   || ends_with_ci(name, ".h")   ||
+        ends_with_ci(name, ".cpp") || ends_with_ci(name, ".hpp") ||
+        ends_with_ci(name, ".cc")  || ends_with_ci(name, ".cxx") ||
+        ends_with_ci(name, ".java")|| ends_with_ci(name, ".cs")  ||
+        ends_with_ci(name, ".go")  || ends_with_ci(name, ".rs")
+    ) { syntax_mode = SYNTAX_CLIKE; return; }
+    if (ends_with_ci(name, ".js") || ends_with_ci(name, ".ts")) { syntax_mode = SYNTAX_CLIKE; return; }
+    if (ends_with_ci(name, ".py")) { syntax_mode = SYNTAX_PY; return; }
+    if (
+        ends_with_ci(name, ".sh") || ends_with_ci(name, ".bash") ||
+        ends_with_ci(name, ".zsh")|| ends_with_ci(name, ".fish")
+    ) { syntax_mode = SYNTAX_SHELL; return; }
+    if (ends_with_ci(name, ".json")) { syntax_mode = SYNTAX_JSON; return; }
+    if (
+        ends_with_ci(name, ".html") || ends_with_ci(name, ".htm") ||
+        ends_with_ci(name, ".xml")  || ends_with_ci(name, ".xhtml") ||
+        ends_with_ci(name, ".css")
+    ) { syntax_mode = SYNTAX_HTML; return; }
+    if (ends_with_ci(name, ".md") || ends_with_ci(name, ".markdown")) { syntax_mode = SYNTAX_MD; return; }
+    if (
+        ends_with_ci(name, ".ini") || ends_with_ci(name, ".cfg") || ends_with_ci(name, ".conf") ||
+        ends_with_ci(name, ".toml")|| ends_with_ci(name, ".yaml")|| ends_with_ci(name, ".yml")
+    ) { syntax_mode = SYNTAX_INI; return; }
+    if (ends_with_ci(name, ".sql")) { syntax_mode = SYNTAX_SQL; return; }
+}
+
+static int is_ascii_letter(char c) {
+    return ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' );
+}
+static int is_ascii_alnum(char c) {
+    return is_ascii_letter(c) || (c >= '0' && c <= '9');
+}
+static int word_in_list_ci(const unsigned char *s, size_t n, const char *const *list, size_t list_sz) {
+    for (size_t i = 0; i < list_sz; ++i) {
+        const char *w = list[i];
+        size_t wl = strlen(w);
+        if (wl == n) {
+            size_t j = 0; int eq = 1;
+            for (; j < n; ++j) {
+                char a = (char)s[j], b = w[j];
+                if (a >= 'A' && a <= 'Z') a = (char)(a - 'A' + 'a');
+                if (b >= 'A' && b <= 'Z') b = (char)(b - 'A' + 'a');
+                if (a != b) { eq = 0; break; }
+            }
+            if (eq) return 1;
+        }
+    }
+    return 0;
+}
+
+static void write_ansi(const char *seq) {
+    term_write((const unsigned char *)seq, strlen(seq));
+}
+
+static void write_bytes(const unsigned char *s, size_t n) {
+    if (n > 0) term_write(s, n);
+}
+
+static void highlight_write(const unsigned char *s, size_t len) {
+    if (len == 0) return;
+    // ANSI color palette
+    static const char *C_RESET   = "\x1b[0m";
+    static const char *C_COMMENT = "\x1b[90m"; // bright black / gray
+    static const char *C_STRING  = "\x1b[32m"; // green
+    static const char *C_NUMBER  = "\x1b[35m"; // magenta
+    static const char *C_KEYWORD = "\x1b[36m"; // cyan
+    static const char *C_CONST   = "\x1b[33m"; // yellow
+    static const char *C_TAG     = "\x1b[34m"; // blue
+
+    // Keyword lists (minimal but popular)
+    static const char *const KW_CLIKE[] = {
+        "if","else","for","while","switch","case","break","continue","return","struct","union","enum","typedef","static","const","volatile","extern","inline","sizeof","void","char","short","int","long","float","double","signed","unsigned","class","public","private","protected","template","typename","using","namespace","virtual","override","final","try","catch","throw","new","delete","this","operator","import","export","from","package","interface","extends","implements","function","const","let","var","async","await","yield"
+    };
+    static const char *const KW_PY[] = {
+        "def","class","return","if","elif","else","for","while","break","continue","try","except","finally","with","as","lambda","import","from","global","nonlocal","pass","raise","yield","assert","del","True","False","None"
+    };
+    static const char *const KW_SH[] = {
+        "if","then","else","elif","fi","for","in","do","done","case","esac","while","until","function","select","time","coproc","local","export","readonly","return"
+    };
+    static const char *const KW_SQL[] = {
+        "select","from","where","group","by","order","insert","into","update","delete","create","table","alter","drop","join","left","right","inner","outer","on","as","and","or","not","null","is","like","in","exists","limit","offset","union","distinct","having","case","when","then","end"
+    };
+
+    const char *current = C_RESET;
+    write_ansi(C_RESET);
+
+    size_t i = 0;
+    int in_string = 0; // quote char stored in in_string (' or " or `)
+
+    while (i < len) {
+        unsigned char c = s[i];
+
+        // Simple string handling (supports escapes)
+        if (!in_string && (c == '"' || c == '\'' || c == '`')) {
+            in_string = (int)c;
+            if (current != C_STRING) { write_ansi(C_STRING); current = C_STRING; }
+            write_bytes(&s[i], 1);
+            i += 1;
+            continue;
+        }
+        if (in_string) {
+            if (c == '\\' && i + 1 < len) {
+                // escape sequence
+                write_bytes(&s[i], 2);
+                i += 2;
+                continue;
+            }
+            write_bytes(&s[i], 1);
+            if (c == (unsigned char)in_string) {
+                in_string = 0;
+                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+            }
+            i += 1;
+            continue;
+        }
+
+        // Comments (single-line)
+        if (syntax_mode == SYNTAX_CLIKE) {
+            if (i + 1 < len && s[i] == '/' && s[i + 1] == '/') {
+                if (current != C_COMMENT) { write_ansi(C_COMMENT); current = C_COMMENT; }
+                write_bytes(&s[i], len - i);
+                i = len;
+                break;
+            }
+        }
+        if (syntax_mode == SYNTAX_PY || syntax_mode == SYNTAX_SHELL || syntax_mode == SYNTAX_INI) {
+            if (s[i] == '#') {
+                if (current != C_COMMENT) { write_ansi(C_COMMENT); current = C_COMMENT; }
+                write_bytes(&s[i], len - i);
+                i = len;
+                break;
+            }
+        }
+        if (syntax_mode == SYNTAX_SQL) {
+            if (i + 1 < len && s[i] == '-' && s[i + 1] == '-') {
+                if (current != C_COMMENT) { write_ansi(C_COMMENT); current = C_COMMENT; }
+                write_bytes(&s[i], len - i);
+                i = len;
+                break;
+            }
+        }
+        if (syntax_mode == SYNTAX_HTML) {
+            if (i + 3 < len && s[i] == '<' && s[i + 1] == '!' && s[i + 2] == '-' && s[i + 3] == '-') {
+                if (current != C_COMMENT) { write_ansi(C_COMMENT); current = C_COMMENT; }
+                write_bytes(&s[i], len - i);
+                i = len;
+                break;
+            }
+        }
+
+        // Numbers
+        if ((c >= '0' && c <= '9') || (c == '.' && i + 1 < len && s[i + 1] >= '0' && s[i + 1] <= '9')) {
+            size_t start = i;
+            if (c == '0' && i + 1 < len && (s[i + 1] == 'x' || s[i + 1] == 'X')) {
+                i += 2;
+                while (i < len) {
+                    unsigned char d = s[i];
+                    if ((d >= '0' && d <= '9') || (d >= 'a' && d <= 'f') || (d >= 'A' && d <= 'F')) {
+                        ++i;
+                    } else {
+                        break;
+                    }
+                }
+            } else {
+                ++i;
+                while (i < len && ((s[i] >= '0' && s[i] <= '9') || s[i] == '_' )) ++i;
+                if (i < len && (s[i] == '.' || s[i] == 'e' || s[i] == 'E')) {
+                    ++i; while (i < len && ((s[i] >= '0' && s[i] <= '9') || s[i] == '+' || s[i] == '-' )) ++i;
+                }
+            }
+            if (current != C_NUMBER) { write_ansi(C_NUMBER); current = C_NUMBER; }
+            write_bytes(&s[start], i - start);
+            if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+            continue;
+        }
+
+        // Words / keywords / booleans / null
+        if (is_ascii_letter((char)c)) {
+            size_t start = i; ++i;
+            while (i < len && is_ascii_alnum((char)s[i])) ++i;
+            size_t n = i - start;
+            int colored = 0;
+
+            // JSON specific: keys are in quotes, handled as strings. Highlight booleans/null.
+            if (
+                (syntax_mode == SYNTAX_JSON || syntax_mode == SYNTAX_INI || syntax_mode == SYNTAX_PY || syntax_mode == SYNTAX_SHELL || syntax_mode == SYNTAX_SQL || syntax_mode == SYNTAX_CLIKE) &&
+                (word_in_list_ci(s + start, n, (const char*[]){"true","false","null"}, 3))
+            ) {
+                if (current != C_CONST) { write_ansi(C_CONST); current = C_CONST; }
+                write_bytes(&s[start], n);
+                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+                colored = 1;
+            } else if (syntax_mode == SYNTAX_CLIKE && word_in_list_ci(s + start, n, KW_CLIKE, sizeof(KW_CLIKE)/sizeof(KW_CLIKE[0]))) {
+                if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
+                write_bytes(&s[start], n);
+                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+                colored = 1;
+            } else if (syntax_mode == SYNTAX_PY && word_in_list_ci(s + start, n, KW_PY, sizeof(KW_PY)/sizeof(KW_PY[0]))) {
+                if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
+                write_bytes(&s[start], n);
+                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+                colored = 1;
+            } else if (syntax_mode == SYNTAX_SHELL && word_in_list_ci(s + start, n, KW_SH, sizeof(KW_SH)/sizeof(KW_SH[0]))) {
+                if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
+                write_bytes(&s[start], n);
+                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+                colored = 1;
+            } else if (syntax_mode == SYNTAX_SQL && word_in_list_ci(s + start, n, KW_SQL, sizeof(KW_SQL)/sizeof(KW_SQL[0]))) {
+                if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
+                write_bytes(&s[start], n);
+                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+                colored = 1;
+            } else if (syntax_mode == SYNTAX_HTML) {
+                // Inside tags, color tag/attr names lightly
+                // We don't know context from rowbuf; just color words immediately after '<' or before '='
+                size_t prev = start > 0 ? start - 1 : start;
+                if ((prev < start && s[prev] == '<') || (i < len && s[i] == '=')) {
+                    if (current != C_TAG) { write_ansi(C_TAG); current = C_TAG; }
+                    write_bytes(&s[start], n);
+                    if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+                    colored = 1;
+                }
+            } else if (syntax_mode == SYNTAX_INI) {
+                // Keys before '=' or ':'
+                if (i < len && (s[i] == '=' || s[i] == ':')) {
+                    if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
+                    write_bytes(&s[start], n);
+                    if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+                    colored = 1;
+                }
+            }
+
+            if (!colored) {
+                write_bytes(&s[start], n);
+            }
+            continue;
+        }
+
+        // HTML tags and angle brackets
+        if (syntax_mode == SYNTAX_HTML && (c == '<' || c == '>')) {
+            if (current != C_TAG) { write_ansi(C_TAG); current = C_TAG; }
+            write_bytes(&s[i], 1);
+            if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+            i += 1;
+            continue;
+        }
+
+        // Default: passthrough
+        if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
+        write_bytes(&s[i], 1);
+        i += 1;
+    }
+
+    if (current != C_RESET) write_ansi(C_RESET);
+}
+
 void render_refresh(void) {
     size_t digits = 1;
     term_get_win_size(&editor.cols, &editor.rows);
@@ -25,6 +332,8 @@ void render_refresh(void) {
     lineno_pad = show_line_numbers ? digits + 2 : 0;
     ensure_screen_buffer();
     render_scroll();
+    // Detect syntax on each refresh (cheap and robust when file changes)
+    detect_syntax_from_path();
     static uint64_t last_state = 0;
     uint64_t state = editor.file.buffer.digest
                    ^ (uint64_t)(uintptr_t)editor.top_line
@@ -296,24 +605,38 @@ static void draw_line(size_t row, const unsigned char *line, size_t len) {
         return;
     }
     prev_len = editor.screen_lens[row];
-    if (prev_len == len && memcmp(editor.screen_lines[row], line, len) == 0) {
-        return;
+    // If highlighting is enabled, force redraw of the line content so ANSI can be emitted.
+    if (syntax_mode == SYNTAX_NONE) {
+        if (prev_len == len && memcmp(editor.screen_lines[row], line, len) == 0) {
+            return;
+        }
     }
     common_len = 0;
     while (
+        syntax_mode == SYNTAX_NONE &&
         common_len < prev_len &&
         common_len < len &&
         editor.screen_lines[row][common_len] == line[common_len]
     ) {
         common_len++;
     }
-    while (common_len > 0 && is_continuation_byte(line[common_len])) {
-        common_len--;
+    if (syntax_mode == SYNTAX_NONE) {
+        while (common_len > 0 && is_continuation_byte(line[common_len])) {
+            common_len--;
+        }
+    } else {
+        // Force full rewrite when highlighting to ensure correct colorization
+        common_len = 0;
     }
     common_width = length_to_width((unsigned char *)editor.screen_lines[row], common_len);
     term_set_cursor(common_width, row);
-    if (common_len < len) {
-        term_write(line + common_len, len - common_len);
+    if (syntax_mode == SYNTAX_NONE) {
+        if (common_len < len) {
+            term_write(line + common_len, len - common_len);
+        }
+    } else {
+        // Colored write of the whole (or remaining) line segment
+        highlight_write(line + common_len, len - common_len);
     }
     new_width = common_width + length_to_width(line + common_len, len - common_len);
     old_width = length_to_width((unsigned char *)editor.screen_lines[row], prev_len);

--- a/src/render.c
+++ b/src/render.c
@@ -1,4 +1,5 @@
 #include "yoc.h"
+#include "syntax.h"
 #include <string.h>
 #include <stdio.h>
 #include <limits.h>
@@ -16,311 +17,6 @@ static bool_t   prev_scrollbar_visible = FALSE;
 static uint64_t cached_digest          = 0;
 bool_t          show_line_numbers      = TRUE;
 
-// --- Minimal syntax highlighting (terminal ANSI) ---
-// We keep stored screen buffers plain. We only inject ANSI during writes.
-// This ensures width calculations remain correct.
-
-typedef enum {
-    SYNTAX_NONE = 0,
-    SYNTAX_CLIKE,
-    SYNTAX_PY,
-    SYNTAX_SHELL,
-    SYNTAX_JSON,
-    SYNTAX_HTML,
-    SYNTAX_MD,
-    SYNTAX_INI,
-    SYNTAX_SQL,
-} SyntaxMode;
-
-static SyntaxMode syntax_mode = SYNTAX_NONE;
-
-static int ends_with_ci(const char *s, const char *ext) {
-    size_t ls = strlen(s), le = strlen(ext);
-    if (le > ls) return 0;
-    s += ls - le;
-    for (size_t i = 0; i < le; ++i) {
-        char a = s[i], b = ext[i];
-        if (a >= 'A' && a <= 'Z') a = (char)(a - 'A' + 'a');
-        if (b >= 'A' && b <= 'Z') b = (char)(b - 'A' + 'a');
-        if (a != b) return 0;
-    }
-    return 1;
-}
-
-static int equals_ci(const char *a, const char *b) {
-    size_t la = strlen(a), lb = strlen(b);
-    if (la != lb) return 0;
-    for (size_t i = 0; i < la; ++i) {
-        char ca = a[i], cb = b[i];
-        if (ca >= 'A' && ca <= 'Z') ca = (char)(ca - 'A' + 'a');
-        if (cb >= 'A' && cb <= 'Z') cb = (char)(cb - 'A' + 'a');
-        if (ca != cb) return 0;
-    }
-    return 1;
-}
-
-static void detect_syntax_from_path(void) {
-    const char *path = editor.file.path;
-    const char *name = path && path[0] ? extract_filename(path) : "";
-    syntax_mode = SYNTAX_NONE;
-    if (name[0] == '\0') return;
-    if (equals_ci(name, "makefile")) { syntax_mode = SYNTAX_INI; return; }
-    if (
-        ends_with_ci(name, ".c")   || ends_with_ci(name, ".h")   ||
-        ends_with_ci(name, ".cpp") || ends_with_ci(name, ".hpp") ||
-        ends_with_ci(name, ".cc")  || ends_with_ci(name, ".cxx") ||
-        ends_with_ci(name, ".java")|| ends_with_ci(name, ".cs")  ||
-        ends_with_ci(name, ".go")  || ends_with_ci(name, ".rs")
-    ) { syntax_mode = SYNTAX_CLIKE; return; }
-    if (ends_with_ci(name, ".js") || ends_with_ci(name, ".ts")) { syntax_mode = SYNTAX_CLIKE; return; }
-    if (ends_with_ci(name, ".py")) { syntax_mode = SYNTAX_PY; return; }
-    if (
-        ends_with_ci(name, ".sh") || ends_with_ci(name, ".bash") ||
-        ends_with_ci(name, ".zsh")|| ends_with_ci(name, ".fish")
-    ) { syntax_mode = SYNTAX_SHELL; return; }
-    if (ends_with_ci(name, ".json")) { syntax_mode = SYNTAX_JSON; return; }
-    if (
-        ends_with_ci(name, ".html") || ends_with_ci(name, ".htm") ||
-        ends_with_ci(name, ".xml")  || ends_with_ci(name, ".xhtml") ||
-        ends_with_ci(name, ".css")
-    ) { syntax_mode = SYNTAX_HTML; return; }
-    if (ends_with_ci(name, ".md") || ends_with_ci(name, ".markdown")) { syntax_mode = SYNTAX_MD; return; }
-    if (
-        ends_with_ci(name, ".ini") || ends_with_ci(name, ".cfg") || ends_with_ci(name, ".conf") ||
-        ends_with_ci(name, ".toml")|| ends_with_ci(name, ".yaml")|| ends_with_ci(name, ".yml")
-    ) { syntax_mode = SYNTAX_INI; return; }
-    if (ends_with_ci(name, ".sql")) { syntax_mode = SYNTAX_SQL; return; }
-}
-
-static int is_ascii_letter(char c) {
-    return ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' );
-}
-static int is_ascii_alnum(char c) {
-    return is_ascii_letter(c) || (c >= '0' && c <= '9');
-}
-static int word_in_list_ci(const unsigned char *s, size_t n, const char *const *list, size_t list_sz) {
-    for (size_t i = 0; i < list_sz; ++i) {
-        const char *w = list[i];
-        size_t wl = strlen(w);
-        if (wl == n) {
-            size_t j = 0; int eq = 1;
-            for (; j < n; ++j) {
-                char a = (char)s[j], b = w[j];
-                if (a >= 'A' && a <= 'Z') a = (char)(a - 'A' + 'a');
-                if (b >= 'A' && b <= 'Z') b = (char)(b - 'A' + 'a');
-                if (a != b) { eq = 0; break; }
-            }
-            if (eq) return 1;
-        }
-    }
-    return 0;
-}
-
-static void write_ansi(const char *seq) {
-    term_write((const unsigned char *)seq, strlen(seq));
-}
-
-static void write_bytes(const unsigned char *s, size_t n) {
-    if (n > 0) term_write(s, n);
-}
-
-static void highlight_write(const unsigned char *s, size_t len) {
-    if (len == 0) return;
-    // ANSI color palette
-    static const char *C_RESET   = "\x1b[0m";
-    static const char *C_COMMENT = "\x1b[90m"; // bright black / gray
-    static const char *C_STRING  = "\x1b[32m"; // green
-    static const char *C_NUMBER  = "\x1b[35m"; // magenta
-    static const char *C_KEYWORD = "\x1b[36m"; // cyan
-    static const char *C_CONST   = "\x1b[33m"; // yellow
-    static const char *C_TAG     = "\x1b[34m"; // blue
-
-    // Keyword lists (minimal but popular)
-    static const char *const KW_CLIKE[] = {
-        "if","else","for","while","switch","case","break","continue","return","struct","union","enum","typedef","static","const","volatile","extern","inline","sizeof","void","char","short","int","long","float","double","signed","unsigned","class","public","private","protected","template","typename","using","namespace","virtual","override","final","try","catch","throw","new","delete","this","operator","import","export","from","package","interface","extends","implements","function","const","let","var","async","await","yield"
-    };
-    static const char *const KW_PY[] = {
-        "def","class","return","if","elif","else","for","while","break","continue","try","except","finally","with","as","lambda","import","from","global","nonlocal","pass","raise","yield","assert","del","True","False","None"
-    };
-    static const char *const KW_SH[] = {
-        "if","then","else","elif","fi","for","in","do","done","case","esac","while","until","function","select","time","coproc","local","export","readonly","return"
-    };
-    static const char *const KW_SQL[] = {
-        "select","from","where","group","by","order","insert","into","update","delete","create","table","alter","drop","join","left","right","inner","outer","on","as","and","or","not","null","is","like","in","exists","limit","offset","union","distinct","having","case","when","then","end"
-    };
-
-    const char *current = C_RESET;
-    write_ansi(C_RESET);
-
-    size_t i = 0;
-    int in_string = 0; // quote char stored in in_string (' or " or `)
-
-    while (i < len) {
-        unsigned char c = s[i];
-
-        // Simple string handling (supports escapes)
-        if (!in_string && (c == '"' || c == '\'' || c == '`')) {
-            in_string = (int)c;
-            if (current != C_STRING) { write_ansi(C_STRING); current = C_STRING; }
-            write_bytes(&s[i], 1);
-            i += 1;
-            continue;
-        }
-        if (in_string) {
-            if (c == '\\' && i + 1 < len) {
-                // escape sequence
-                write_bytes(&s[i], 2);
-                i += 2;
-                continue;
-            }
-            write_bytes(&s[i], 1);
-            if (c == (unsigned char)in_string) {
-                in_string = 0;
-                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-            }
-            i += 1;
-            continue;
-        }
-
-        // Comments (single-line)
-        if (syntax_mode == SYNTAX_CLIKE) {
-            if (i + 1 < len && s[i] == '/' && s[i + 1] == '/') {
-                if (current != C_COMMENT) { write_ansi(C_COMMENT); current = C_COMMENT; }
-                write_bytes(&s[i], len - i);
-                i = len;
-                break;
-            }
-        }
-        if (syntax_mode == SYNTAX_PY || syntax_mode == SYNTAX_SHELL || syntax_mode == SYNTAX_INI) {
-            if (s[i] == '#') {
-                if (current != C_COMMENT) { write_ansi(C_COMMENT); current = C_COMMENT; }
-                write_bytes(&s[i], len - i);
-                i = len;
-                break;
-            }
-        }
-        if (syntax_mode == SYNTAX_SQL) {
-            if (i + 1 < len && s[i] == '-' && s[i + 1] == '-') {
-                if (current != C_COMMENT) { write_ansi(C_COMMENT); current = C_COMMENT; }
-                write_bytes(&s[i], len - i);
-                i = len;
-                break;
-            }
-        }
-        if (syntax_mode == SYNTAX_HTML) {
-            if (i + 3 < len && s[i] == '<' && s[i + 1] == '!' && s[i + 2] == '-' && s[i + 3] == '-') {
-                if (current != C_COMMENT) { write_ansi(C_COMMENT); current = C_COMMENT; }
-                write_bytes(&s[i], len - i);
-                i = len;
-                break;
-            }
-        }
-
-        // Numbers
-        if ((c >= '0' && c <= '9') || (c == '.' && i + 1 < len && s[i + 1] >= '0' && s[i + 1] <= '9')) {
-            size_t start = i;
-            if (c == '0' && i + 1 < len && (s[i + 1] == 'x' || s[i + 1] == 'X')) {
-                i += 2;
-                while (i < len) {
-                    unsigned char d = s[i];
-                    if ((d >= '0' && d <= '9') || (d >= 'a' && d <= 'f') || (d >= 'A' && d <= 'F')) {
-                        ++i;
-                    } else {
-                        break;
-                    }
-                }
-            } else {
-                ++i;
-                while (i < len && ((s[i] >= '0' && s[i] <= '9') || s[i] == '_' )) ++i;
-                if (i < len && (s[i] == '.' || s[i] == 'e' || s[i] == 'E')) {
-                    ++i; while (i < len && ((s[i] >= '0' && s[i] <= '9') || s[i] == '+' || s[i] == '-' )) ++i;
-                }
-            }
-            if (current != C_NUMBER) { write_ansi(C_NUMBER); current = C_NUMBER; }
-            write_bytes(&s[start], i - start);
-            if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-            continue;
-        }
-
-        // Words / keywords / booleans / null
-        if (is_ascii_letter((char)c)) {
-            size_t start = i; ++i;
-            while (i < len && is_ascii_alnum((char)s[i])) ++i;
-            size_t n = i - start;
-            int colored = 0;
-
-            // JSON specific: keys are in quotes, handled as strings. Highlight booleans/null.
-            if (
-                (syntax_mode == SYNTAX_JSON || syntax_mode == SYNTAX_INI || syntax_mode == SYNTAX_PY || syntax_mode == SYNTAX_SHELL || syntax_mode == SYNTAX_SQL || syntax_mode == SYNTAX_CLIKE) &&
-                (word_in_list_ci(s + start, n, (const char*[]){"true","false","null"}, 3))
-            ) {
-                if (current != C_CONST) { write_ansi(C_CONST); current = C_CONST; }
-                write_bytes(&s[start], n);
-                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-                colored = 1;
-            } else if (syntax_mode == SYNTAX_CLIKE && word_in_list_ci(s + start, n, KW_CLIKE, sizeof(KW_CLIKE)/sizeof(KW_CLIKE[0]))) {
-                if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
-                write_bytes(&s[start], n);
-                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-                colored = 1;
-            } else if (syntax_mode == SYNTAX_PY && word_in_list_ci(s + start, n, KW_PY, sizeof(KW_PY)/sizeof(KW_PY[0]))) {
-                if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
-                write_bytes(&s[start], n);
-                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-                colored = 1;
-            } else if (syntax_mode == SYNTAX_SHELL && word_in_list_ci(s + start, n, KW_SH, sizeof(KW_SH)/sizeof(KW_SH[0]))) {
-                if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
-                write_bytes(&s[start], n);
-                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-                colored = 1;
-            } else if (syntax_mode == SYNTAX_SQL && word_in_list_ci(s + start, n, KW_SQL, sizeof(KW_SQL)/sizeof(KW_SQL[0]))) {
-                if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
-                write_bytes(&s[start], n);
-                if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-                colored = 1;
-            } else if (syntax_mode == SYNTAX_HTML) {
-                // Inside tags, color tag/attr names lightly
-                // We don't know context from rowbuf; just color words immediately after '<' or before '='
-                size_t prev = start > 0 ? start - 1 : start;
-                if ((prev < start && s[prev] == '<') || (i < len && s[i] == '=')) {
-                    if (current != C_TAG) { write_ansi(C_TAG); current = C_TAG; }
-                    write_bytes(&s[start], n);
-                    if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-                    colored = 1;
-                }
-            } else if (syntax_mode == SYNTAX_INI) {
-                // Keys before '=' or ':'
-                if (i < len && (s[i] == '=' || s[i] == ':')) {
-                    if (current != C_KEYWORD) { write_ansi(C_KEYWORD); current = C_KEYWORD; }
-                    write_bytes(&s[start], n);
-                    if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-                    colored = 1;
-                }
-            }
-
-            if (!colored) {
-                write_bytes(&s[start], n);
-            }
-            continue;
-        }
-
-        // HTML tags and angle brackets
-        if (syntax_mode == SYNTAX_HTML && (c == '<' || c == '>')) {
-            if (current != C_TAG) { write_ansi(C_TAG); current = C_TAG; }
-            write_bytes(&s[i], 1);
-            if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-            i += 1;
-            continue;
-        }
-
-        // Default: passthrough
-        if (current != C_RESET) { write_ansi(C_RESET); current = C_RESET; }
-        write_bytes(&s[i], 1);
-        i += 1;
-    }
-
-    if (current != C_RESET) write_ansi(C_RESET);
-}
 
 void render_refresh(void) {
     size_t digits = 1;
@@ -332,8 +28,8 @@ void render_refresh(void) {
     lineno_pad = show_line_numbers ? digits + 2 : 0;
     ensure_screen_buffer();
     render_scroll();
-    // Detect syntax on each refresh (cheap and robust when file changes)
-    detect_syntax_from_path();
+    // Inform syntax system of current file path (no-op if unchanged)
+    syntax_set_file(editor.file.path);
     static uint64_t last_state = 0;
     uint64_t state = editor.file.buffer.digest
                    ^ (uint64_t)(uintptr_t)editor.top_line
@@ -606,37 +302,37 @@ static void draw_line(size_t row, const unsigned char *line, size_t len) {
     }
     prev_len = editor.screen_lens[row];
     // If highlighting is enabled, force redraw of the line content so ANSI can be emitted.
-    if (syntax_mode == SYNTAX_NONE) {
+    if (!syntax_enabled()) {
         if (prev_len == len && memcmp(editor.screen_lines[row], line, len) == 0) {
             return;
         }
     }
     common_len = 0;
-    while (
-        syntax_mode == SYNTAX_NONE &&
-        common_len < prev_len &&
-        common_len < len &&
-        editor.screen_lines[row][common_len] == line[common_len]
-    ) {
-        common_len++;
-    }
-    if (syntax_mode == SYNTAX_NONE) {
+    if (!syntax_enabled()) {
+        while (
+            common_len < prev_len &&
+            common_len < len &&
+            editor.screen_lines[row][common_len] == line[common_len]
+        ) {
+            common_len++;
+        }
         while (common_len > 0 && is_continuation_byte(line[common_len])) {
             common_len--;
         }
     } else {
-        // Force full rewrite when highlighting to ensure correct colorization
+        // Force full rewrite when highlighting to ensure correct color emission
         common_len = 0;
     }
     common_width = length_to_width((unsigned char *)editor.screen_lines[row], common_len);
     term_set_cursor(common_width, row);
-    if (syntax_mode == SYNTAX_NONE) {
+    if (syntax_enabled()) {
+        if (common_len < len) {
+            syntax_write_line(line + common_len, len - common_len);
+        }
+    } else {
         if (common_len < len) {
             term_write(line + common_len, len - common_len);
         }
-    } else {
-        // Colored write of the whole (or remaining) line segment
-        highlight_write(line + common_len, len - common_len);
     }
     new_width = common_width + length_to_width(line + common_len, len - common_len);
     old_width = length_to_width((unsigned char *)editor.screen_lines[row], prev_len);

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -1,0 +1,115 @@
+#include "syntax.h"
+#include <string.h>
+
+// Registry entry
+typedef struct {
+    const char *const *exts;
+    size_t num_exts;
+    void (*write)(const unsigned char *s, size_t len);
+} Entry;
+
+// Forward declarations for writers (can be provided by syntax/*.c)
+__attribute__((weak)) void syntax_write_clike(const unsigned char *s, size_t len);
+__attribute__((weak)) void syntax_write_py(const unsigned char *s, size_t len);
+__attribute__((weak)) void syntax_write_sh(const unsigned char *s, size_t len);
+__attribute__((weak)) void syntax_write_json(const unsigned char *s, size_t len);
+__attribute__((weak)) void syntax_write_html(const unsigned char *s, size_t len);
+__attribute__((weak)) void syntax_write_ini(const unsigned char *s, size_t len);
+__attribute__((weak)) void syntax_write_sql(const unsigned char *s, size_t len);
+__attribute__((weak)) void syntax_write_md(const unsigned char *s, size_t len);
+
+// Minimal fallback which just writes plain text without color
+static void write_plain(const unsigned char *s, size_t len) {
+    term_write(s, len);
+}
+
+// If a writer is not supplied by a language module, use plain
+static void (*pick_or_plain(void (*fn)(const unsigned char*, size_t)))(const unsigned char*, size_t) {
+    return fn ? fn : write_plain;
+}
+
+static const char *exts_clike[] = { ".c", ".h", ".cpp", ".hpp", ".cc", ".cxx", ".java", ".cs", ".go", ".rs", ".js", ".ts" };
+static const char *exts_py[]    = { ".py" };
+static const char *exts_sh[]    = { ".sh", ".bash", ".zsh", ".fish" };
+static const char *exts_json[]  = { ".json" };
+static const char *exts_html[]  = { ".html", ".htm", ".xml", ".xhtml", ".css" };
+static const char *exts_md[]    = { ".md", ".markdown" };
+static const char *exts_ini[]   = { ".ini", ".cfg", ".conf", ".toml", ".yaml", ".yml", "makefile" };
+static const char *exts_sql[]   = { ".sql" };
+
+static Entry registry[] = {
+    { exts_clike, sizeof(exts_clike)/sizeof(exts_clike[0]), NULL },
+    { exts_py,    sizeof(exts_py)/sizeof(exts_py[0]),       NULL },
+    { exts_sh,    sizeof(exts_sh)/sizeof(exts_sh[0]),       NULL },
+    { exts_json,  sizeof(exts_json)/sizeof(exts_json[0]),   NULL },
+    { exts_html,  sizeof(exts_html)/sizeof(exts_html[0]),   NULL },
+    { exts_md,    sizeof(exts_md)/sizeof(exts_md[0]),       NULL },
+    { exts_ini,   sizeof(exts_ini)/sizeof(exts_ini[0]),     NULL },
+    { exts_sql,   sizeof(exts_sql)/sizeof(exts_sql[0]),     NULL },
+};
+
+static void init_registry(void) {
+    registry[0].write = pick_or_plain(syntax_write_clike);
+    registry[1].write = pick_or_plain(syntax_write_py);
+    registry[2].write = pick_or_plain(syntax_write_sh);
+    registry[3].write = pick_or_plain(syntax_write_json);
+    registry[4].write = pick_or_plain(syntax_write_html);
+    registry[5].write = pick_or_plain(syntax_write_md);
+    registry[6].write = pick_or_plain(syntax_write_ini);
+    registry[7].write = pick_or_plain(syntax_write_sql);
+}
+
+static const Entry *current = NULL;
+
+static int equals_ci(const char *a, const char *b) {
+    size_t la = strlen(a), lb = strlen(b);
+    if (la != lb) return 0;
+    for (size_t i = 0; i < la; ++i) {
+        char ca = a[i], cb = b[i];
+        if (ca >= 'A' && ca <= 'Z') ca = (char)(ca - 'A' + 'a');
+        if (cb >= 'A' && cb <= 'Z') cb = (char)(cb - 'A' + 'a');
+        if (ca != cb) return 0;
+    }
+    return 1;
+}
+
+static int ends_with_ci(const char *s, const char *ext) {
+    size_t ls = strlen(s), le = strlen(ext);
+    if (le > ls) return 0;
+    s += ls - le;
+    for (size_t i = 0; i < le; ++i) {
+        char a = s[i], b = ext[i];
+        if (a >= 'A' && a <= 'Z') a = (char)(a - 'A' + 'a');
+        if (b >= 'A' && b <= 'Z') b = (char)(b - 'A' + 'a');
+        if (a != b) return 0;
+    }
+    return 1;
+}
+
+void syntax_set_file(const char *path) {
+    init_registry();
+    current = NULL;
+    if (!path || !path[0]) return;
+    const char *name = extract_filename(path);
+    for (size_t i = 0; i < sizeof(registry)/sizeof(registry[0]); ++i) {
+        for (size_t k = 0; k < registry[i].num_exts; ++k) {
+            const char *ext = registry[i].exts[k];
+            if (*ext == '.' ? ends_with_ci(name, ext) : equals_ci(name, ext)) {
+                current = &registry[i];
+                return;
+            }
+        }
+    }
+}
+
+bool_t syntax_enabled(void) {
+    return current != NULL && current->write != NULL && current->write != write_plain;
+}
+
+void syntax_write_line(const unsigned char *s, size_t len) {
+    if (!current || !current->write) {
+        write_plain(s, len);
+        return;
+    }
+    current->write(s, len);
+}

--- a/syntax/clike.c
+++ b/syntax/clike.c
@@ -1,0 +1,32 @@
+#include "syntax.h"
+#include <string.h>
+
+static void ansi(const char *seq) { term_write((const unsigned char*)seq, strlen(seq)); }
+static void out(const unsigned char *s, size_t n) { if (n) term_write(s, n); }
+
+static int is_l(char c){return ((c>='a'&&c<='z')||(c>='A'&&c<='Z')||c=='_');}
+static int is_an(char c){return is_l(c)||(c>='0'&&c<='9');}
+static int in_list_ci(const unsigned char*s,size_t n,const char*const*L,size_t LN){
+  for(size_t i=0;i<LN;++i){const char*w=L[i];size_t m=strlen(w);if(m==n){size_t j=0;int ok=1;for(;j<n;++j){char a=(char)s[j],b=w[j];if(a>='A'&&a<='Z')a=(char)(a- 'A'+'a');if(b>='A'&&b<='Z')b=(char)(b- 'A'+'a');if(a!=b){ok=0;break;}}if(ok)return 1;}}return 0;
+}
+
+void syntax_write_clike(const unsigned char *s, size_t len) {
+  static const char *K[]={"if","else","for","while","switch","case","break","continue","return","struct","union","enum","typedef","static","const","volatile","extern","inline","sizeof","void","char","short","int","long","float","double","signed","unsigned","class","public","private","protected","template","typename","using","namespace","virtual","override","final","try","catch","throw","new","delete","this","operator","import","export","from","package","interface","extends","implements","function","const","let","var","async","await","yield"};
+  const char *R="\x1b[0m", *C="\x1b[90m", *S="\x1b[32m", *N="\x1b[35m", *KW="\x1b[36m";
+  ansi(R);
+  size_t i=0; int str=0; while(i<len){unsigned char c=s[i];
+    if(!str&&(i+1<len&&s[i]=='/'&&s[i+1]=='/')){ansi(C); out(s+i,len-i); break;}
+    if(!str&&(c=='"'||c=='\'')) {str=c; ansi(S); out(&s[i++],1); continue;}
+    if(str){ if(c=='\\'&&i+1<len){ out(&s[i],2); i+=2; continue;} out(&s[i],1); if(c==str){str=0; ansi(R);} i++; continue;}
+    if((c>='0'&&c<='9')||(c=='.'&&i+1<len&&s[i+1]>='0'&&s[i+1]<='9')){
+      size_t st=i; if(c=='0'&&i+1<len&&(s[i+1]=='x'||s[i+1]=='X')){ i+=2; while(i<len){unsigned char d=s[i]; if((d>='0'&&d<='9')||(d>='a'&&d<='f')||(d>='A'&&d<='F')) i++; else break;} }
+      else { i++; while(i<len&&((s[i]>='0'&&s[i]<='9')||s[i]=='_')) i++; if(i<len&&(s[i]=='.'||s[i]=='e'||s[i]=='E')){ i++; while(i<len&&((s[i]>='0'&&s[i]<='9')||s[i]=='+'||s[i]=='-')) i++; } }
+      ansi(N); out(s+st,i-st); ansi(R); continue; }
+    if(is_l((char)c)){
+      size_t st=i; i++; while(i<len&&is_an((char)s[i])) i++; size_t n=i-st;
+      if(in_list_ci(s+st,n,K,sizeof(K)/sizeof(K[0]))){ ansi(KW); out(s+st,n); ansi(R);} else { out(s+st,n);} continue;
+    }
+    out(&s[i],1); i++;
+  }
+  ansi(R);
+}

--- a/syntax/html.c
+++ b/syntax/html.c
@@ -1,0 +1,27 @@
+#include "syntax.h"
+#include <string.h>
+
+static void ansi(const char *s){ term_write((const unsigned char*)s, strlen(s)); }
+static void out(const unsigned char*s,size_t n){ if(n) term_write(s,n); }
+static int is_l(char c){return ((c>='a'&&c<='z')||(c>='A'&&c<='Z')||c=='_'||c=='-');}
+static int is_an(char c){return is_l(c)||(c>='0'&&c<='9');}
+
+void syntax_write_html(const unsigned char *s, size_t len){
+  const char *R="\x1b[0m", *TAG="\x1b[34m", *ATTR="\x1b[36m", *S="\x1b[32m", *C="\x1b[90m";
+  ansi(R);
+  // HTML comments
+  if(len>=4 && s[0]=='<' && s[1]=='!' && s[2]=='-' && s[3]=='-'){ ansi(C); out(s,len); ansi(R); return; }
+  size_t i=0; int str=0; int in_tag=0;
+  while(i<len){ unsigned char c=s[i];
+    if(!str && c=='<'){ in_tag=1; ansi(TAG); out(&s[i++],1); continue; }
+    if(in_tag && !str && c=='>'){ out(&s[i++],1); ansi(R); in_tag=0; continue; }
+    if(!str && (c=='"'||c=='\'')){ str=c; ansi(S); out(&s[i++],1); continue; }
+    if(str){ if(c=='\\'&&i+1<len){ out(&s[i],2); i+=2; continue; } out(&s[i],1); if(c==str){ str=0; if(in_tag) ansi(TAG); else ansi(R);} i++; continue; }
+    if(in_tag && is_l((char)c)){
+      size_t st=i; i++; while(i<len&&is_an((char)s[i])) i++; size_t n=i-st; out(s+st,n); continue;
+    }
+    if(in_tag && c=='='){ ansi(ATTR); out(&s[i++],1); ansi(TAG); continue; }
+    out(&s[i],1); i++;
+  }
+  ansi(R);
+}

--- a/syntax/ini.c
+++ b/syntax/ini.c
@@ -1,0 +1,29 @@
+#include "syntax.h"
+#include <string.h>
+
+static void ansi(const char *s){ term_write((const unsigned char*)s, strlen(s)); }
+static void out(const unsigned char*s,size_t n){ if(n) term_write(s,n); }
+static int is_l(char c){return ((c>='a'&&c<='z')||(c>='A'&&c<='Z')||c=='_'||c=='-');}
+static int is_an(char c){return is_l(c)||(c>='0'&&c<='9');}
+
+void syntax_write_ini(const unsigned char *s, size_t len){
+  const char *R="\x1b[0m", *K="\x1b[36m", *C="\x1b[90m", *S="\x1b[32m";
+  ansi(R);
+  // Section headers [section]
+  if(len>0 && s[0]=='['){ ansi(K); out(s,len); ansi(R); return; }
+  // Comments begin with # or ;
+  if(len>0 && (s[0]=='#' || s[0]==';')){ ansi(C); out(s,len); ansi(R); return; }
+  // Key = value
+  size_t i=0; if(i<len && is_l((char)s[i])){
+    size_t st=i; i++; while(i<len&&is_an((char)s[i])) i++;
+    if(i<len && (s[i]=='='||s[i]==':')){ ansi(K); out(s+st,i-st); ansi(R); out(&s[i],1); i++; }
+  }
+  // rest: highlight strings and comments trailing
+  int str=0; while(i<len){ unsigned char c=s[i];
+    if(!str&&(c=='"'||c=='\'')){ str=c; ansi(S); out(&s[i++],1); continue; }
+    if(str){ if(c=='\\'&&i+1<len){ out(&s[i],2); i+=2; continue; } out(&s[i],1); if(c==str){ str=0; ansi(R);} i++; continue; }
+    if(c=='#' || c==';'){ ansi(C); out(s+i,len-i); break; }
+    out(&s[i],1); i++;
+  }
+  ansi(R);
+}

--- a/syntax/md.c
+++ b/syntax/md.c
@@ -1,0 +1,17 @@
+#include "syntax.h"
+#include <string.h>
+
+static void ansi(const char *s){ term_write((const unsigned char*)s, strlen(s)); }
+static void out(const unsigned char*s,size_t n){ if(n) term_write(s,n); }
+
+void syntax_write_md(const unsigned char *s, size_t len){
+  const char *R="\x1b[0m", *H="\x1b[36m", *C="\x1b[32m", *E="\x1b[33m", *L="\x1b[34m";
+  ansi(R);
+  if(len>0 && s[0]=='#'){ ansi(H); out(s,len); ansi(R); return; }
+  if(len>=3 && s[0]=='`'&&s[1]=='`'&&s[2]=='`'){ ansi(C); out(s,len); ansi(R); return; }
+  // highlight links [text](url)
+  size_t i=0; while(i<len){ unsigned char c=s[i]; if(c=='['){ size_t st=i; while(i<len&&s[i]!=']') i++; if(i<len && i+1<len && s[i]==']' && s[i+1]=='('){ i+=2; while(i<len && s[i]!=')') i++; ansi(L); out(s+st,i-st+(i<len)); ansi(R); if(i<len) i++; continue; } i=st; }
+    if(c=='*' || c=='_'){ ansi(E); out(&s[i],1); ansi(R); i++; continue; }
+    out(&s[i],1); i++; }
+  ansi(R);
+}

--- a/syntax/py.c
+++ b/syntax/py.c
@@ -1,0 +1,23 @@
+#include "syntax.h"
+#include <string.h>
+
+static void ansi(const char *s){ term_write((const unsigned char*)s, strlen(s)); }
+static void out(const unsigned char*s,size_t n){ if(n) term_write(s,n); }
+static int is_l(char c){return ((c>='a'&&c<='z')||(c>='A'&&c<='Z')||c=='_');}
+static int is_an(char c){return is_l(c)||(c>='0'&&c<='9');}
+static int in_ci(const unsigned char*s,size_t n,const char*const*L,size_t LN){for(size_t i=0;i<LN;++i){ const char*w=L[i]; size_t m=strlen(w); if(m==n){ int ok=1; for(size_t j=0;j<n;++j){ char a=(char)s[j], b=w[j]; if(a>='A'&&a<='Z') a=(char)(a-'A'+'a'); if(b>='A'&&b<='Z') b=(char)(b-'A'+'a'); if(a!=b){ok=0;break;} } if(ok) return 1; } } return 0; }
+
+void syntax_write_py(const unsigned char *s, size_t len){
+  static const char *K[]={"def","class","return","if","elif","else","for","while","break","continue","try","except","finally","with","as","lambda","import","from","global","nonlocal","pass","raise","yield","assert","del","True","False","None"};
+  const char *R="\x1b[0m", *C="\x1b[90m", *S="\x1b[32m", *N="\x1b[35m", *KW="\x1b[36m";
+  ansi(R);
+  if(len>0 && s[0]=='#'){ ansi(C); out(s,len); ansi(R); return; }
+  size_t i=0; int str=0; while(i<len){ unsigned char c=s[i];
+    if(!str && (c=='"'||c=='\'')){ str=c; ansi(S); out(&s[i++],1); continue; }
+    if(str){ if(c=='\\'&&i+1<len){ out(&s[i],2); i+=2; continue; } out(&s[i],1); if(c==str){ str=0; ansi(R);} i++; continue; }
+    if((c>='0'&&c<='9')||(c=='.'&&i+1<len&&s[i+1]>='0'&&s[i+1]<='9')){ size_t st=i; i++; while(i<len&&((s[i]>='0'&&s[i]<='9')||s[i]=='.')) i++; ansi(N); out(s+st,i-st); ansi(R); continue; }
+    if(is_l((char)c)){ size_t st=i; i++; while(i<len&&is_an((char)s[i])) i++; size_t n=i-st; if(in_ci(s+st,n,K,sizeof(K)/sizeof(K[0]))){ ansi(KW); out(s+st,n); ansi(R);} else { out(s+st,n);} continue; }
+    out(&s[i],1); i++;
+  }
+  ansi(R);
+}

--- a/syntax/sh.c
+++ b/syntax/sh.c
@@ -1,0 +1,26 @@
+#include "syntax.h"
+#include <string.h>
+
+static void ansi(const char *s){ term_write((const unsigned char*)s, strlen(s)); }
+static void out(const unsigned char*s,size_t n){ if(n) term_write(s,n); }
+static int is_l(char c){return ((c>='a'&&c<='z')||(c>='A'&&c<='Z')||c=='_');}
+static int is_an(char c){return is_l(c)||(c>='0'&&c<='9');}
+static int in_ci(const unsigned char*s,size_t n,const char*const*L,size_t LN){
+  for(size_t i=0;i<LN;++i){ const char*w=L[i]; size_t m=strlen(w); if(m==n){ int ok=1; for(size_t j=0;j<n;++j){ char a=(char)s[j], b=w[j]; if(a>='A'&&a<='Z') a=(char)(a-'A'+'a'); if(b>='A'&&b<='Z') b=(char)(b-'A'+'a'); if(a!=b){ok=0;break;}} if(ok)return 1; } }
+  return 0;
+}
+
+void syntax_write_sh(const unsigned char *s, size_t len){
+  static const char *K[]={"if","then","else","elif","fi","for","in","do","done","case","esac","while","until","function","select","time","coproc","local","export","readonly","return"};
+  const char *R="\x1b[0m", *C="\x1b[90m", *S="\x1b[32m", *N="\x1b[35m", *KW="\x1b[36m";
+  ansi(R);
+  if(len>0 && s[0]=='#'){ ansi(C); out(s,len); ansi(R); return; }
+  size_t i=0; int str=0; while(i<len){ unsigned char c=s[i];
+    if(!str && (c=='"'||c=='\'')){ str=c; ansi(S); out(&s[i++],1); continue; }
+    if(str){ if(c=='\\'&&i+1<len){ out(&s[i],2); i+=2; continue; } out(&s[i],1); if(c==str){ str=0; ansi(R);} i++; continue; }
+    if((c>='0'&&c<='9')||(c=='.'&&i+1<len&&s[i+1]>='0'&&s[i+1]<='9')){ size_t st=i; i++; while(i<len&&((s[i]>='0'&&s[i]<='9')||s[i]=='.')) i++; ansi(N); out(s+st,i-st); ansi(R); continue; }
+    if(is_l((char)c)){ size_t st=i; i++; while(i<len&&is_an((char)s[i])) i++; size_t n=i-st; if(in_ci(s+st,n,K,sizeof(K)/sizeof(K[0]))){ ansi(KW); out(s+st,n); ansi(R);} else { out(s+st,n);} continue; }
+    out(&s[i],1); i++;
+  }
+  ansi(R);
+}

--- a/syntax/simple_json.c
+++ b/syntax/simple_json.c
@@ -1,0 +1,25 @@
+#include "syntax.h"
+#include <string.h>
+
+static void ansi(const char *seq){ term_write((const unsigned char*)seq, strlen(seq)); }
+static void out(const unsigned char *s,size_t n){ if(n) term_write(s,n); }
+static int is_l(char c){return ((c>='a'&&c<='z')||(c>='A'&&c<='Z')||c=='_');}
+static int is_an(char c){return is_l(c)||(c>='0'&&c<='9');}
+static int eq_ci(const unsigned char*s,size_t n,const char*w){ size_t m=strlen(w); if(m!=n) return 0; for(size_t i=0;i<n;++i){ char a=(char)s[i], b=w[i]; if(a>='A'&&a<='Z') a=(char)(a-'A'+'a'); if(b>='A'&&b<='Z') b=(char)(b-'A'+'a'); if(a!=b) return 0;} return 1; }
+
+void syntax_write_json(const unsigned char *s, size_t len){
+  const char *R="\x1b[0m", *STR="\x1b[32m", *NUM="\x1b[35m", *CST="\x1b[33m", *PUNC="\x1b[34m";
+  ansi(R);
+  size_t i=0; int str=0; while(i<len){ unsigned char c=s[i];
+    if(!str&&(c=='"')){ str=c; ansi(STR); out(&s[i++],1); continue; }
+    if(str){ if(c=='\\'&&i+1<len){ out(&s[i],2); i+=2; continue; } out(&s[i],1); if(c=='"'){ str=0; ansi(R);} i++; continue; }
+    if((c>='0'&&c<='9')||(c=='-'&&i+1<len&&s[i+1]>='0'&&s[i+1]<='9')){ size_t st=i; i++; while(i<len&&((s[i]>='0'&&s[i]<='9')||s[i]=='.'||s[i]=='e'||s[i]=='E'||s[i]=='+'||s[i]=='-')) i++; ansi(NUM); out(s+st,i-st); ansi(R); continue; }
+    if(is_l((char)c)){
+      size_t st=i; i++; while(i<len&&is_an((char)s[i])) i++; size_t n=i-st;
+      if(eq_ci(s+st,n,"true")||eq_ci(s+st,n,"false")||eq_ci(s+st,n,"null")){ ansi(CST); out(s+st,n); ansi(R);} else { out(s+st,n);} continue;
+    }
+    if(c=='{'||c=='}'||c=='['||c==']'||c==':'||c==','){ ansi(PUNC); out(&s[i],1); ansi(R); i++; continue; }
+    out(&s[i],1); i++;
+  }
+  ansi(R);
+}

--- a/syntax/sql.c
+++ b/syntax/sql.c
@@ -1,0 +1,23 @@
+#include "syntax.h"
+#include <string.h>
+
+static void ansi(const char *s){ term_write((const unsigned char*)s, strlen(s)); }
+static void out(const unsigned char*s,size_t n){ if(n) term_write(s,n); }
+static int is_l(char c){return ((c>='a'&&c<='z')||(c>='A'&&c<='Z')||c=='_');}
+static int is_an(char c){return is_l(c)||(c>='0'&&c<='9');}
+static int in_ci(const unsigned char*s,size_t n,const char*const*L,size_t LN){ for(size_t i=0;i<LN;++i){ const char*w=L[i]; size_t m=strlen(w); if(m==n){ int ok=1; for(size_t j=0;j<n;++j){ char a=(char)s[j], b=w[j]; if(a>='A'&&a<='Z') a=(char)(a-'A'+'a'); if(b>='A'&&b<='Z') b=(char)(b-'A'+'a'); if(a!=b){ok=0;break;} } if(ok) return 1; } } return 0; }
+
+void syntax_write_sql(const unsigned char *s, size_t len){
+  static const char *K[]={"select","from","where","group","by","order","insert","into","update","delete","create","table","alter","drop","join","left","right","inner","outer","on","as","and","or","not","null","is","like","in","exists","limit","offset","union","distinct","having","case","when","then","end"};
+  const char *R="\x1b[0m", *C="\x1b[90m", *S="\x1b[32m", *N="\x1b[35m", *KW="\x1b[36m";
+  ansi(R);
+  if(len>=2 && s[0]=='-'&&s[1]=='-'){ ansi(C); out(s,len); ansi(R); return; }
+  size_t i=0; int str=0; while(i<len){ unsigned char c=s[i];
+    if(!str&&(c=='"'||c=='\'')){ str=c; ansi(S); out(&s[i++],1); continue; }
+    if(str){ if(c=='\\'&&i+1<len){ out(&s[i],2); i+=2; continue; } out(&s[i],1); if(c==str){ str=0; ansi(R);} i++; continue; }
+    if((c>='0'&&c<='9')||(c=='.'&&i+1<len&&s[i+1]>='0'&&s[i+1]<='9')){ size_t st=i; i++; while(i<len&&((s[i]>='0'&&s[i]<='9')||s[i]=='.')) i++; ansi(N); out(s+st,i-st); ansi(R); continue; }
+    if(is_l((char)c)){ size_t st=i; i++; while(i<len&&is_an((char)s[i])) i++; size_t n=i-st; if(in_ci(s+st,n,K,sizeof(K)/sizeof(K[0]))){ ansi(KW); out(s+st,n); ansi(R);} else { out(s+st,n);} continue; }
+    out(&s[i],1); i++;
+  }
+  ansi(R);
+}


### PR DESCRIPTION
Add minimal, terminal-style syntax highlighting by injecting ANSI color codes during rendering, without modifying the buffer.

This implementation detects syntax based on file extension and applies highlighting for strings, numbers, comments, and keywords for common languages (C-like, Python, Shell, JSON, HTML, Markdown, INI/YAML/TOML, SQL). This approach ensures that existing buffer management and width calculations remain unaffected, adhering to the "minimal code changes" requirement.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4e3b946-e059-4daf-b090-639a935c85fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4e3b946-e059-4daf-b090-639a935c85fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

